### PR TITLE
Allow Mercurial version numbers with the "rc0", etc., suffixes

### DIFF
--- a/src/Mercurial.Net/ClientExecutable.cs
+++ b/src/Mercurial.Net/ClientExecutable.cs
@@ -238,7 +238,7 @@ namespace Mercurial
                 {
                     '\n', '\r'
                 }, StringSplitOptions.RemoveEmptyEntries).First();
-            var re = new Regex(@"\(version\s+(?<version>[0-9.]+)(\+\d+-[a-f0-9]+)?\)", RegexOptions.IgnoreCase);
+            var re = new Regex(@"\(version\s+(?<version>[0-9.]+)(?:(?:\+\d+-[a-f0-9]+)|(?:rc\d+))?\)", RegexOptions.IgnoreCase);
             Match ma = re.Match(firstLine);
             if (!ma.Success)
                 throw new InvalidOperationException(


### PR DESCRIPTION
The TortoiseHg About box has started recommending people install what look like release candidate versions; e.g., "tortoisehg-5.9rc0-x64.msi" installs version "5.9rc1":
```
% hg --version
Mercurial Distributed SCM (version 5.9rc1)
(see https://mercurial-scm.org for more information)

Copyright (C) 2005-2021 Olivia Mackall and others
This is free software; see the source for copying conditions. There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
The trailing "rc1" trips up `DoGetVersion()`.

This commits updates the regular expression to accept these new kinds of version numbers.