### PR TITLE
Fix Commit timestamp unit test

### DIFF
--- a/src/Mercurial.Net.Tests/CommitTests.cs
+++ b/src/Mercurial.Net.Tests/CommitTests.cs
@@ -204,14 +204,14 @@ namespace Mercurial.Tests
         {
             Repo.Init();
             File.WriteAllText(Path.Combine(Repo.Path, "test1.txt"), "dummy content");
-            var timestamp = new DateTime(2010, 1, 17, 18, 23, 59);
+            var timestamp = new DateTime(2010, 1, 17, 18, 23, 59, DateTimeKind.Utc);
             Repo.Commit(
                 "dummy", new CommitCommand
                 {
                     AddRemove = true,
                     OverrideTimestamp = timestamp,
                 });
-            Assert.That(Repo.Log().First().Timestamp, Is.EqualTo(timestamp));
+            Assert.That(Repo.Log().First().Timestamp.ToUniversalTime(), Is.EqualTo(timestamp));
         }
 
         [Test]


### PR DESCRIPTION
Fix unit test `Commit_WithOverriddenTimestamp_CommitsWithThatTimestamp()` to handle time zones.

The commit updates the `timestamp` variable to explicitly use `DateTimeKind.Utc` since UTC is what the resulting command line provides to Mercurial.  It also converts the resulting log `Timestamp` to UTC to perform the comparison.