### PR TITLE
Fix project files encoding unit tests

### DIFF
--- a/src/Mercurial.Net.Tests.Hook/Mercurial.Net.Tests.Hook.csproj
+++ b/src/Mercurial.Net.Tests.Hook/Mercurial.Net.Tests.Hook.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/Mercurial.Net.Tests/Mercurial.Net.Tests.csproj
+++ b/src/Mercurial.Net.Tests/Mercurial.Net.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/Mercurial.Net/Mercurial.Net.csproj
+++ b/src/Mercurial.Net/Mercurial.Net.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>


### PR DESCRIPTION
Unit code `EnsureAllFilesInProjectsAreUtf8Encoded()` fails for some CSPROJ files because they include the unnecessary UTF-8 BOM.  This commit removes the BOM from those CSPROJ files so the unit tests can pass.